### PR TITLE
add model light uniforms and GPU skinning path

### DIFF
--- a/modules/modelling/build.gradle
+++ b/modules/modelling/build.gradle
@@ -69,6 +69,11 @@ neoForge {
             systemProperty 'kasuga.profileModel', 'true'
             systemProperty 'kasuga.profileModel.intervalMs', '1000'
             systemProperty 'kasuga.profileModel.animateTestBone', 'true'
+            systemProperty 'kasuga.profileModel.animateStress', 'true'
+            systemProperty 'kasuga.profileModel.animateSelection', 'small'
+            systemProperty 'kasuga.profileModel.animateBoneCount', '32'
+            systemProperty 'kasuga.profileModel.animateTranslation', '0.2'
+            systemProperty 'kasuga.modelGpuSkinning', 'true'
             client()
 
             // Comma-separated list of namespaces to load gametests from. Empty = all namespaces.

--- a/modules/modelling/src/main/java/lib/kasuga/rendering/models/mc/backend/KsgVertexBuffer.java
+++ b/modules/modelling/src/main/java/lib/kasuga/rendering/models/mc/backend/KsgVertexBuffer.java
@@ -31,12 +31,18 @@ import org.jetbrains.annotations.Nullable;
 import org.joml.Vector2f;
 import org.joml.Vector3f;
 import org.joml.Vector4f;
+import org.joml.Matrix3f;
+import org.joml.Matrix4f;
+import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL15;
+import org.lwjgl.opengl.GL30;
+import org.lwjgl.opengl.GL31;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
 import java.util.*;
 
 public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderable {
@@ -69,6 +75,13 @@ public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderabl
     private float[] skinningWeights = new float[0];
     private Map<Bone, int[]> skinningIndicesByBone = Map.of();
     private BitSet dirtySkinningIndices = new BitSet();
+    private Bone[] gpuSkinningBones = new Bone[0];
+    private Map<Bone, Integer> gpuSkinningBoneIndex = Map.of();
+    private Map<Bone, Transform> gpuSkinningBindInverses = Map.of();
+    private boolean gpuSkinningDataReady = false;
+    private int gpuBoneTransformBufferId = 0;
+    private int gpuBoneTransformTextureId = 0;
+    private FloatBuffer gpuBoneTransformUploadCache;
     private ByteBuffer uploadCache;
     private boolean uploadCacheValid = false;
     private int uploadCacheVertexSize = -1;
@@ -99,6 +112,7 @@ public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderabl
     private int irisGpuBufferPackedOverlay = -1;
     private boolean irisGpuBufferReadAlpha = true;
     private float irisGpuBufferBrightness = Float.NaN;
+    private final BitSet irisGpuDirtyVertices = new BitSet();
 
     @Getter
     private boolean closed = false;
@@ -169,11 +183,32 @@ public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderabl
             irisGpuBuffer.close();
             irisGpuBuffer = null;
         }
+        if (gpuBoneTransformBufferId != 0) {
+            GL15.glDeleteBuffers(gpuBoneTransformBufferId);
+            gpuBoneTransformBufferId = 0;
+        }
+        if (gpuBoneTransformTextureId != 0) {
+            GL11.glDeleteTextures(gpuBoneTransformTextureId);
+            gpuBoneTransformTextureId = 0;
+        }
+        if (gpuBoneTransformUploadCache != null) {
+            MemoryUtil.memFree(gpuBoneTransformUploadCache);
+            gpuBoneTransformUploadCache = null;
+        }
         closed = true;
     }
 
     public void checkClosed() {
         if (closed) throw new IllegalStateException("This buffer is already closed!");
+    }
+
+    public static boolean isGpuSkinningEnabled() {
+        String env = System.getenv("KASUGA_MODEL_GPU_SKINNING");
+        if (env != null && !env.isBlank()) {
+            return Boolean.parseBoolean(env);
+        }
+        String property = System.getProperty("kasuga.modelGpuSkinning");
+        return property != null && !property.isBlank() && Boolean.parseBoolean(property);
     }
 
     private void findUv1AndUv2(VertexFormat format) {
@@ -288,6 +323,7 @@ public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderabl
 
     private void invalidateIrisGpuBuffer() {
         irisGpuBufferValid = false;
+        irisGpuDirtyVertices.clear();
     }
 
     @Deprecated
@@ -435,6 +471,8 @@ public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderabl
         Objects.requireNonNull(shader);
         shader.setCurrentPose(pose);
         shader.setEmissiveStrength(emissiveStrength);
+        shader.setLightData(brightness, packedLight, packedOverlay);
+        shader.setGpuSkinningState(gpuSkinningDataReady && isGpuSkinningEnabled(), gpuBoneTransformTextureId);
         shader.apply();
         AccessorBufferBuilder accessor = (AccessorBufferBuilder) builder;
         ByteBufferBuilder buf = accessor.getBuffer();
@@ -505,17 +543,20 @@ public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderabl
         int dstNormalOffset = offsets.get(VertexFormatElement.NORMAL);
         int dstUv1LightOffset = offsets.get(VertexFormatElement.UV1);
         int dstUv2LightOffset = offsets.get(VertexFormatElement.UV2);
+        int dstBoneIndicesOffset = offsets.get(RenderState.BONE_INDICES);
+        int dstBoneWeightsOffset = offsets.get(RenderState.BONE_WEIGHTS);
         int srcPositionOffset = bufOffsets.get(VertexFormatElement.POSITION);
         int srcColorOffset = bufOffsets.get(VertexFormatElement.COLOR);
         int srcUv0Offset = bufOffsets.get(VertexFormatElement.UV0);
         int srcTangentOffset = bufOffsets.get(RenderState.TANGENT);
         int srcNormalOffset = bufOffsets.get(VertexFormatElement.NORMAL);
+        int srcBoneIndicesOffset = bufOffsets.get(RenderState.BONE_INDICES);
+        int srcBoneWeightsOffset = bufOffsets.get(RenderState.BONE_WEIGHTS);
         int srcUv1Offset = uv1_element == null ? -1 : bufOffsets.get(uv1_element);
         int srcUv2Offset = uv2_element == null ? -1 : bufOffsets.get(uv2_element);
         int dstUv1Offset = uv1_element == null ? -1 : offsets.get(uv1_element);
         int dstUv2Offset = uv2_element == null ? -1 : offsets.get(uv2_element);
         long bufferPointer = MemoryUtil.memAddress(buffer);
-        float colorScale = brightness / 255f;
         for (int i = startInclusive; i < endExclusive; i++) {
             long vertexPointer = pointer + (long) (i - startInclusive) * avs;
             int vertexOffset = i * vertexSize;
@@ -535,9 +576,9 @@ public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderabl
             int mr = buffer.get(bufOffset + 7) & 0xff;
 
             int af = readAlpha ? (a * ma) / 255 : ma;
-            int bf = (int) (b * mb * colorScale);
-            int gf = (int) (g * mg * colorScale);
-            int rf = (int) (r * mr * colorScale);
+            int bf = (b * mb) / 255;
+            int gf = (g * mg) / 255;
+            int rf = (r * mr) / 255;
             int colorFinal = af << 24 | bf << 16 | gf << 8 | rf;
             MemoryUtil.memPutInt(offset, IS_LITTLE_ENDIAN ?
                     colorFinal :
@@ -560,6 +601,8 @@ public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderabl
             if (uv2_element != null) {
                 MemoryUtil.memCopy(sourcePointer + srcUv2Offset, vertexPointer + dstUv2Offset, 8L);
             }
+            MemoryUtil.memCopy(sourcePointer + srcBoneIndicesOffset, vertexPointer + dstBoneIndicesOffset, 16L);
+            MemoryUtil.memCopy(sourcePointer + srcBoneWeightsOffset, vertexPointer + dstBoneWeightsOffset, 16L);
         }
     }
 
@@ -574,18 +617,26 @@ public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderabl
         checkClosed();
         Objects.requireNonNull(shader);
         int gpuVertexSize = RenderState.UML_VERTEX_FORMAT.getVertexSize();
-        boolean cacheValid = isStaticGpuBufferValid(gpuVertexSize, brightness, packedLight, packedOverlay, readAlpha);
+        boolean layoutValid = isStaticGpuBufferLayoutValid(gpuVertexSize, readAlpha);
         String cacheState = "hit";
-        if (!cacheValid) {
+        int dirtyVertices = staticGpuDirtyVertices.cardinality();
+        if (!layoutValid || dirtyVertices * 4 >= numVertices * 3) {
             uploadStaticGpuBuffer(gpuVertexSize, brightness, packedLight, packedOverlay, readAlpha);
             cacheState = "miss";
-        } else if (!staticGpuDirtyVertices.isEmpty()) {
-            uploadStaticGpuRanges(gpuVertexSize, brightness, packedLight, packedOverlay, readAlpha);
-            cacheState = "range";
+        } else {
+            boolean lightUpdated = updateStaticLightData(gpuVertexSize, brightness, packedLight, packedOverlay, readAlpha);
+            if (dirtyVertices > 0) {
+                uploadStaticGpuRanges(gpuVertexSize, brightness, packedLight, packedOverlay, readAlpha);
+                cacheState = lightUpdated ? "light+range" : "range";
+            } else if (lightUpdated) {
+                cacheState = "light";
+            }
         }
         long drawStart = ModelProfiler.start();
         shader.setCurrentPose(pose);
         shader.setEmissiveStrength(emissiveStrength);
+        shader.setLightData(brightness, packedLight, packedOverlay);
+        shader.setGpuSkinningState(gpuSkinningDataReady && isGpuSkinningEnabled(), gpuBoneTransformTextureId);
         renderType.setupRenderState();
 
         VertexBuffer bufferToUse = staticGpuBuffer;
@@ -636,13 +687,18 @@ public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderabl
         }
     }
 
-    private boolean isStaticGpuBufferValid(int vertexSize, float brightness, int packedLight, int packedOverlay, boolean readAlpha) {
+    private boolean isStaticGpuBufferLayoutValid(int vertexSize, boolean readAlpha) {
         return staticGpuBufferValid &&
                 staticGpuBuffer != null &&
                 staticGpuBufferVertexSize == vertexSize &&
+                staticGpuBufferReadAlpha == readAlpha;
+    }
+
+    private boolean isStaticGpuBufferLightingValid(float brightness, int packedLight, int packedOverlay) {
+        return staticGpuBufferValid &&
+                staticGpuBuffer != null &&
                 staticGpuBufferPackedLight == packedLight &&
                 staticGpuBufferPackedOverlay == packedOverlay &&
-                staticGpuBufferReadAlpha == readAlpha &&
                 Float.compare(staticGpuBufferBrightness, brightness) == 0;
     }
 
@@ -694,6 +750,36 @@ public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderabl
             ModelProfiler.record("gpu.uploadStatic.full", uploadStart,
                     "bytes=" + size + ", vertices=" + numVertices);
         }
+    }
+
+    public boolean updateStaticLightData(float brightness, int packedLight, int packedOverlay, boolean readAlpha) {
+        checkClosed();
+        int gpuVertexSize = RenderState.UML_VERTEX_FORMAT.getVertexSize();
+        return updateStaticLightData(gpuVertexSize, brightness, packedLight, packedOverlay, readAlpha);
+    }
+
+    public boolean updateStaticLightData(float brightness, int packedLight, int packedOverlay) {
+        return updateStaticLightData(brightness, packedLight, packedOverlay, true);
+    }
+
+    private boolean updateStaticLightData(int vertexSize, float brightness, int packedLight, int packedOverlay, boolean readAlpha) {
+        if (!isStaticGpuBufferLayoutValid(vertexSize, readAlpha) ||
+                isStaticGpuBufferLightingValid(brightness, packedLight, packedOverlay)) {
+            return false;
+        }
+        long uploadStart = ModelProfiler.start();
+        staticGpuBufferBrightness = brightness;
+        staticGpuBufferPackedLight = packedLight;
+        staticGpuBufferPackedOverlay = packedOverlay;
+        staticGpuBufferReadAlpha = readAlpha;
+        staticGpuBufferValid = true;
+        if (ModelProfiler.enabled()) {
+            ModelProfiler.record("gpu.uploadStatic.light", uploadStart,
+                    "bytes=0" +
+                            ", vertices=" + numVertices +
+                            ", mode=uniform");
+        }
+        return true;
     }
 
     private void uploadStaticGpuRanges(int vertexSize, float brightness, int packedLight, int packedOverlay, boolean readAlpha) {
@@ -889,6 +975,9 @@ public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderabl
         ArrayList<Transform> bindInverses = new ArrayList<>();
         ArrayList<Float> weights = new ArrayList<>();
         HashMap<Bone, ArrayList<Integer>> indicesByBone = new HashMap<>();
+        HashMap<Bone, Integer> uniqueBoneIndices = new HashMap<>();
+        HashMap<Bone, Transform> uniqueBindInverses = new HashMap<>();
+        ArrayList<Bone> uniqueBones = new ArrayList<>();
         for (int i = 0; i < vertices.size(); i++) {
             Vertex vertex = vertices.get(i);
             Mesh mesh = meshes.get(i);
@@ -910,8 +999,14 @@ public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderabl
                 bones.add(bone);
                 indicesByBone.computeIfAbsent(bone, ignored -> new ArrayList<>()).add(i);
                 Pair<Transform, Transform> bindTransforms = model.getSkeleton().getBoneTransforms().get(bone);
-                bindInverses.add(bindTransforms == null ? null : bindTransforms.getSecond());
+                Transform bindInverse = bindTransforms == null ? null : bindTransforms.getSecond();
+                bindInverses.add(bindInverse);
                 weights.add(pair.getSecond());
+                if (!uniqueBoneIndices.containsKey(bone)) {
+                    uniqueBoneIndices.put(bone, uniqueBones.size());
+                    uniqueBones.add(bone);
+                    uniqueBindInverses.put(bone, bindInverse);
+                }
             }
         }
         this.skinningBones = bones.toArray(new Bone[0]);
@@ -931,6 +1026,50 @@ public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderabl
         }
         this.skinningIndicesByBone = compactIndicesByBone;
         this.dirtySkinningIndices = new BitSet(vertices.size());
+        this.gpuSkinningBones = uniqueBones.toArray(new Bone[0]);
+        this.gpuSkinningBoneIndex = uniqueBoneIndices;
+        this.gpuSkinningBindInverses = uniqueBindInverses;
+        writeGpuSkinningVertexData(vertices);
+    }
+
+    private void writeGpuSkinningVertexData(ArrayList<Vertex> vertices) {
+        if (bufOffsets.get(RenderState.BONE_INDICES) == null || bufOffsets.get(RenderState.BONE_WEIGHTS) == null) {
+            gpuSkinningDataReady = false;
+            return;
+        }
+        int boneIndexOffset = bufOffsets.get(RenderState.BONE_INDICES);
+        int boneWeightOffset = bufOffsets.get(RenderState.BONE_WEIGHTS);
+        int weightedVertices = 0;
+        for (int i = 0; i < vertices.size(); i++) {
+            int vertexIndex = skinningIndices[i];
+            int indexOffset = vertexIndex * vertexSize + boneIndexOffset;
+            int weightOffset = vertexIndex * vertexSize + boneWeightOffset;
+            for (int slot = 0; slot < 4; slot++) {
+                buffer.putInt(indexOffset + slot * 4, 0);
+                buffer.putFloat(weightOffset + slot * 4, 0.0f);
+            }
+            Pair<Bone, Float>[] weights = vertices.get(i).getBinding().getWeights();
+            float totalWeight = 0.0f;
+            int slots = Math.min(weights.length, 4);
+            for (int slot = 0; slot < slots; slot++) {
+                Pair<Bone, Float> weight = weights[slot];
+                Integer boneIndex = gpuSkinningBoneIndex.get(weight.getFirst());
+                if (boneIndex == null) continue;
+                buffer.putInt(indexOffset + slot * 4, boneIndex);
+                buffer.putFloat(weightOffset + slot * 4, weight.getSecond());
+                totalWeight += weight.getSecond();
+            }
+            if (totalWeight > 0.0f) {
+                weightedVertices++;
+                if (totalWeight != 1.0f) {
+                    for (int slot = 0; slot < slots; slot++) {
+                        float weight = buffer.getFloat(weightOffset + slot * 4);
+                        buffer.putFloat(weightOffset + slot * 4, weight / totalWeight);
+                    }
+                }
+            }
+        }
+        gpuSkinningDataReady = weightedVertices > 0 && gpuSkinningBones.length > 0;
     }
 
     private void captureBaseTangents() {
@@ -953,6 +1092,16 @@ public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderabl
         SkeletonInstance skeleton = modelInstance.getSkeletonInstance();
         int vertexCount = skinningVertices.length;
         if (vertexCount == 0) return;
+        if (isGpuSkinningEnabled() && gpuSkinningDataReady) {
+            long uploadStart = ModelProfiler.start();
+            uploadGpuSkinningTransforms(skeleton);
+            if (ModelProfiler.enabled()) {
+                ModelProfiler.record("skinning.gpu.uploadBones", uploadStart,
+                        "bones=" + gpuSkinningBones.length +
+                                ", texels=" + (gpuSkinningBones.length * 8));
+            }
+            return;
+        }
         if (skeleton.isLastFullUpdate()) {
             long updateStart = ModelProfiler.start();
             updateAllSkinning(modelInstance, bridge, skeleton, vertexCount);
@@ -1027,6 +1176,76 @@ public class KsgVertexBuffer implements AutoCloseable, VersionedBackendRenderabl
                             ", dirtyMeshes=" + dirtyMeshes.size() +
                             ", tangents=" + (recalculateTangents ? "mesh" : "skinned"));
         }
+    }
+
+    private void uploadGpuSkinningTransforms(SkeletonInstance skeleton) {
+        RenderSystem.assertOnRenderThread();
+        ensureGpuSkinningObjects();
+        ensureGpuBoneTransformUploadCache(gpuSkinningBones.length * 8 * 4);
+        gpuBoneTransformUploadCache.clear();
+        Map<Bone, Transform> absoluteTransforms = skeleton.getAbsoluteTransforms();
+        Matrix4f transformMatrix = new Matrix4f();
+        Matrix3f normalMatrix = new Matrix3f();
+        for (Bone bone : gpuSkinningBones) {
+            Transform absolute = absoluteTransforms.get(bone);
+            Transform bindInverse = gpuSkinningBindInverses.get(bone);
+            if (absolute == null) {
+                transformMatrix.identity();
+                normalMatrix.identity();
+            } else {
+                transformMatrix.set(absolute.transform());
+                if (bindInverse != null) {
+                    transformMatrix.mul(bindInverse.transform());
+                }
+                normalMatrix.set(absolute.normal());
+            }
+            putMatrix4Columns(gpuBoneTransformUploadCache, transformMatrix);
+            putMatrix3Columns(gpuBoneTransformUploadCache, normalMatrix);
+        }
+        gpuBoneTransformUploadCache.flip();
+        int previousTextureBinding = GL11.glGetInteger(GL31.GL_TEXTURE_BINDING_BUFFER);
+        try {
+            GlStateManager._glBindBuffer(GL31.GL_TEXTURE_BUFFER, gpuBoneTransformBufferId);
+            GL15.glBufferData(GL31.GL_TEXTURE_BUFFER, gpuBoneTransformUploadCache, GL15.GL_DYNAMIC_DRAW);
+            GL11.glBindTexture(GL31.GL_TEXTURE_BUFFER, gpuBoneTransformTextureId);
+            GL31.glTexBuffer(GL31.GL_TEXTURE_BUFFER, GL30.GL_RGBA32F, gpuBoneTransformBufferId);
+        } finally {
+            GL11.glBindTexture(GL31.GL_TEXTURE_BUFFER, previousTextureBinding);
+            GlStateManager._glBindBuffer(GL31.GL_TEXTURE_BUFFER, 0);
+        }
+    }
+
+    private void ensureGpuSkinningObjects() {
+        if (gpuBoneTransformBufferId == 0) {
+            gpuBoneTransformBufferId = GL15.glGenBuffers();
+        }
+        if (gpuBoneTransformTextureId == 0) {
+            gpuBoneTransformTextureId = GL11.glGenTextures();
+        }
+    }
+
+    private void ensureGpuBoneTransformUploadCache(int floatCount) {
+        if (gpuBoneTransformUploadCache != null && gpuBoneTransformUploadCache.capacity() >= floatCount) {
+            return;
+        }
+        if (gpuBoneTransformUploadCache != null) {
+            MemoryUtil.memFree(gpuBoneTransformUploadCache);
+        }
+        gpuBoneTransformUploadCache = MemoryUtil.memAllocFloat(floatCount);
+    }
+
+    private static void putMatrix4Columns(FloatBuffer target, Matrix4f matrix) {
+        target.put(matrix.m00()).put(matrix.m01()).put(matrix.m02()).put(matrix.m03());
+        target.put(matrix.m10()).put(matrix.m11()).put(matrix.m12()).put(matrix.m13());
+        target.put(matrix.m20()).put(matrix.m21()).put(matrix.m22()).put(matrix.m23());
+        target.put(matrix.m30()).put(matrix.m31()).put(matrix.m32()).put(matrix.m33());
+    }
+
+    private static void putMatrix3Columns(FloatBuffer target, Matrix3f matrix) {
+        target.put(matrix.m00()).put(matrix.m01()).put(matrix.m02()).put(0.0f);
+        target.put(matrix.m10()).put(matrix.m11()).put(matrix.m12()).put(0.0f);
+        target.put(matrix.m20()).put(matrix.m21()).put(matrix.m22()).put(0.0f);
+        target.put(0.0f).put(0.0f).put(0.0f).put(1.0f);
     }
 
     private void markStaticGpuDirty(BitSet dirtyIndices, Set<Mesh> dirtyMeshes) {

--- a/modules/modelling/src/main/java/lib/kasuga/rendering/models/mc/backend/MCBridge.java
+++ b/modules/modelling/src/main/java/lib/kasuga/rendering/models/mc/backend/MCBridge.java
@@ -2,6 +2,7 @@ package lib.kasuga.rendering.models.mc.backend;
 
 import com.mojang.blaze3d.platform.NativeImage;
 import lib.kasuga.rendering.models.mc.backend.data_type.MCRenderableContext;
+import lib.kasuga.rendering.models.mc.compat.iris.IrisCompat;
 import lib.kasuga.rendering.models.mc.java_and_bedrock.data.SpriteHolder;
 import lib.kasuga.rendering.models.uml.bridge.Bridge;
 import lib.kasuga.rendering.models.mc.java_and_bedrock.data.MCMeshData;
@@ -31,6 +32,9 @@ public class MCBridge implements Bridge<KsgVertexBuffer> {
 
     @Override
     public HashMap<Vertex, Vertex> transformVertices(Model model, SkeletonInstance skeleton, Vertex[] vertices) {
+        if (KsgVertexBuffer.isGpuSkinningEnabled() && !IrisCompat.isUsingShaderPack()) {
+            return new HashMap<>();
+        }
         if (skeleton.isBindPose()) {
             return new HashMap<>();
         }
@@ -135,6 +139,9 @@ public class MCBridge implements Bridge<KsgVertexBuffer> {
         }
         long finalizeStart = ModelProfiler.start();
         KsgVertexBuffer buffer = builder.build(model);
+        if (KsgVertexBuffer.isGpuSkinningEnabled() && !IrisCompat.isUsingShaderPack()) {
+            buffer.updateForVersion(instance, this);
+        }
         if (ModelProfiler.enabled()) {
             ModelProfiler.record("mcbridge.finalizeVertexBuffer", finalizeStart,
                     "meshes=" + meshes.length + ", vertices=" + (meshes.length * 4));

--- a/modules/modelling/src/main/java/lib/kasuga/rendering/models/mc/backend/RenderState.java
+++ b/modules/modelling/src/main/java/lib/kasuga/rendering/models/mc/backend/RenderState.java
@@ -32,6 +32,8 @@ public class RenderState {
     public static final ResourceLocation DEFAULT_TRANSPARENCY = ResourceLocation.tryBuild(KasugaLib.MODID, "textures/atlas/default_transparency.png");
 
     public static final VertexFormatElement TANGENT;
+    public static final VertexFormatElement BONE_INDICES;
+    public static final VertexFormatElement BONE_WEIGHTS;
 
     public static final ResourceLocation KSG_LAYER_0 = ResourceLocation.tryBuild(KasugaLib.MODID, "textures/atlas/layer_0.png");
     public static final ResourceLocation KSG_LAYER_1 = ResourceLocation.tryBuild(KasugaLib.MODID, "textures/atlas/layer_1.png");
@@ -70,6 +72,18 @@ public class RenderState {
                 VertexFormatElement.Usage.GENERIC,
                 4
         );
+        BONE_INDICES = VertexFormatElement.register(
+                VertexFormatElement.findNextId(), 0,
+                VertexFormatElement.Type.INT,
+                VertexFormatElement.Usage.GENERIC,
+                4
+        );
+        BONE_WEIGHTS = VertexFormatElement.register(
+                VertexFormatElement.findNextId(), 0,
+                VertexFormatElement.Type.FLOAT,
+                VertexFormatElement.Usage.GENERIC,
+                4
+        );
 
         UML_VERTEX_FORMAT = VertexFormat.builder()
                 .add("Position", VertexFormatElement.POSITION)
@@ -79,6 +93,8 @@ public class RenderState {
                 .add("UV2", VertexFormatElement.UV2)
                 .add("Normal", VertexFormatElement.NORMAL)
                 .add("Tangent", TANGENT)
+                .add("BoneIndices", BONE_INDICES)
+                .add("BoneWeights", BONE_WEIGHTS)
                 .padding(13)
                 .build();
 

--- a/modules/modelling/src/main/java/lib/kasuga/rendering/models/mc/backend/data_type/KasugaShaderInstance.java
+++ b/modules/modelling/src/main/java/lib/kasuga/rendering/models/mc/backend/data_type/KasugaShaderInstance.java
@@ -2,6 +2,8 @@ package lib.kasuga.rendering.models.mc.backend.data_type;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.shaders.Uniform;
 import lib.kasuga.rendering.models.mc.Constants;
 import lib.kasuga.rendering.models.uml.math.Transform;
 import lombok.Getter;
@@ -12,6 +14,9 @@ import net.minecraft.server.packs.resources.ResourceProvider;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL13;
+import org.lwjgl.opengl.GL31;
 
 import java.io.IOException;
 
@@ -19,6 +24,7 @@ public class KasugaShaderInstance extends ShaderInstance {
 
     private static final Matrix4f IDENTITY_M4F = new Matrix4f().identity();
     private static final Matrix3f IDENTITY_M3F = new Matrix3f().identity();
+    private static final int BONE_TRANSFORM_TEXTURE_UNIT = 11;
 
     @Getter
     private float emissiveStrength = 1.0f;
@@ -31,6 +37,12 @@ public class KasugaShaderInstance extends ShaderInstance {
 
     @Getter
     private float ambientLightEnhancement = 1.5f;
+
+    private float brightness = 1.0f;
+    private int packedLight = 0;
+    private int packedOverlay = 0;
+    private boolean gpuSkinningEnabled = false;
+    private int boneTransformTextureId = 0;
 
     @Setter
     private @Nullable PoseStack.Pose currentPose;
@@ -88,12 +100,27 @@ public class KasugaShaderInstance extends ShaderInstance {
         setAmbientLightEnhancement(1f);
     }
 
+    public void setLightData(float brightness, int packedLight, int packedOverlay) {
+        this.brightness = brightness;
+        this.packedLight = packedLight;
+        this.packedOverlay = packedOverlay;
+    }
+
+    public void setGpuSkinningState(boolean enabled, int boneTransformTextureId) {
+        this.gpuSkinningEnabled = enabled && boneTransformTextureId > 0;
+        this.boneTransformTextureId = boneTransformTextureId;
+    }
+
     protected void applyAdditionalData() {
         // TODO: 记得同步修改着色器的相关系数
         this.safeGetUniform("ksg_EmissiveStrength").set(this.emissiveStrength);
         this.safeGetUniform("ksg_ParallaxScale").set(this.parallaxScale);
         this.safeGetUniform("ksg_ParallaxSamples").set(this.parallaxSamplerTimes);
         this.safeGetUniform("ksg_AmbientLightEnhancement").set(this.ambientLightEnhancement);
+        this.safeGetUniform("ksg_BrightnessScale").set(this.brightness);
+        this.safeGetUniform("ksg_PackedLight").set(this.packedLight & 0xffff, (this.packedLight >>> 16) & 0xffff);
+        this.safeGetUniform("ksg_PackedOverlay").set(this.packedOverlay & 0xffff, (this.packedOverlay >>> 16) & 0xffff);
+        this.safeGetUniform("ksg_GpuSkinningEnabled").set(this.gpuSkinningEnabled ? 1 : 0);
         if (currentPose != null) {
             this.safeGetUniform("ksg_ModelPoseMat").set(this.currentPose.pose());
             this.safeGetUniform("ksg_ModelNormalMat").set(this.currentPose.normal());
@@ -109,5 +136,18 @@ public class KasugaShaderInstance extends ShaderInstance {
     public void apply() {
         applyAdditionalData();
         super.apply();
+        applyGpuSkinningTexture();
+    }
+
+    private void applyGpuSkinningTexture() {
+        int location = Uniform.glGetUniformLocation(getId(), "ksg_BoneTransforms");
+        if (location < 0) {
+            return;
+        }
+        int previousActiveTexture = GL11.glGetInteger(GL13.GL_ACTIVE_TEXTURE);
+        RenderSystem.activeTexture(GL13.GL_TEXTURE0 + BONE_TRANSFORM_TEXTURE_UNIT);
+        GL11.glBindTexture(GL31.GL_TEXTURE_BUFFER, this.gpuSkinningEnabled ? this.boneTransformTextureId : 0);
+        Uniform.uploadInteger(location, BONE_TRANSFORM_TEXTURE_UNIT);
+        RenderSystem.activeTexture(previousActiveTexture);
     }
 }

--- a/modules/modelling/src/main/resources/assets/kasuga_lib/shaders/core/ksglib_main.json
+++ b/modules/modelling/src/main/resources/assets/kasuga_lib/shaders/core/ksglib_main.json
@@ -21,6 +21,10 @@
     { "name": "ksg_EmissiveStrength", "type":  "float", "count": 1, "values": [ 1.0 ] },
     { "name": "ksg_ModelPoseMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
     { "name": "ksg_ModelNormalMat", "type": "matrix3x3", "count": 9, "values": [ 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0 ] },
+    { "name": "ksg_BrightnessScale", "type": "float", "count": 1, "values": [ 1.0 ] },
+    { "name": "ksg_PackedLight", "type": "int", "count": 2, "values": [ 0, 0 ] },
+    { "name": "ksg_PackedOverlay", "type": "int", "count": 2, "values": [ 0, 0 ] },
+    { "name": "ksg_GpuSkinningEnabled", "type": "int", "count": 1, "values": [ 0 ] },
     { "name": "ksg_ParallaxScale", "type": "float", "count": 1, "values": [ 0.05 ] },
     { "name": "ksg_ParallaxSamples", "type": "int", "count": 1, "values": [ 4 ] },
     { "name": "ksg_AmbientLightEnhancement", "type": "float", "count": 1, "values": [ 1.0 ] }

--- a/modules/modelling/src/main/resources/assets/kasuga_lib/shaders/core/ksglib_main.vsh
+++ b/modules/modelling/src/main/resources/assets/kasuga_lib/shaders/core/ksglib_main.vsh
@@ -10,14 +10,21 @@ in vec2 UV0;
 in ivec2 UV1;
 in ivec2 UV2;
 in vec4 Tangent;
+in ivec4 BoneIndices;
+in vec4 BoneWeights;
 
 uniform mat4 ModelViewMat;
 uniform mat4 ProjMat;
 uniform int FogShape;
 uniform sampler2D Sampler1;
 uniform sampler2D Sampler2;
+uniform samplerBuffer ksg_BoneTransforms;
 uniform mat4 ksg_ModelPoseMat;
 uniform mat3 ksg_ModelNormalMat;
+uniform float ksg_BrightnessScale;
+uniform ivec2 ksg_PackedLight;
+uniform ivec2 ksg_PackedOverlay;
+uniform int ksg_GpuSkinningEnabled;
 
 uniform vec3 Light0_Direction;
 uniform vec3 Light1_Direction;
@@ -33,21 +40,75 @@ out mat3 TBN;
 out vec3 viewLight0_Direction;
 out vec3 viewLight1_Direction;
 
+mat4 ksg_readBoneTransform(int boneIndex) {
+    int base = boneIndex * 8;
+    return mat4(
+        texelFetch(ksg_BoneTransforms, base),
+        texelFetch(ksg_BoneTransforms, base + 1),
+        texelFetch(ksg_BoneTransforms, base + 2),
+        texelFetch(ksg_BoneTransforms, base + 3)
+    );
+}
+
+mat3 ksg_readBoneNormalTransform(int boneIndex) {
+    int base = boneIndex * 8 + 4;
+    return mat3(
+        texelFetch(ksg_BoneTransforms, base).xyz,
+        texelFetch(ksg_BoneTransforms, base + 1).xyz,
+        texelFetch(ksg_BoneTransforms, base + 2).xyz
+    );
+}
+
+void ksg_applyGpuSkinning(inout vec3 position, inout vec3 normal, inout vec4 tangent) {
+    if (ksg_GpuSkinningEnabled == 0) {
+        return;
+    }
+
+    vec4 skinnedPosition = vec4(0.0);
+    vec3 skinnedNormal = vec3(0.0);
+    vec3 skinnedTangent = vec3(0.0);
+    float totalWeight = 0.0;
+    for (int i = 0; i < 4; i++) {
+        float weight = BoneWeights[i];
+        if (weight <= 0.0) {
+            continue;
+        }
+        int boneIndex = BoneIndices[i];
+        mat4 boneTransform = ksg_readBoneTransform(boneIndex);
+        mat3 boneNormal = ksg_readBoneNormalTransform(boneIndex);
+        skinnedPosition += (boneTransform * vec4(position, 1.0)) * weight;
+        skinnedNormal += (boneNormal * normal) * weight;
+        skinnedTangent += (boneNormal * tangent.xyz) * weight;
+        totalWeight += weight;
+    }
+
+    if (totalWeight > 0.0) {
+        position = skinnedPosition.xyz / totalWeight;
+        normal = normalize(skinnedNormal);
+        tangent = vec4(normalize(skinnedTangent), tangent.w);
+    }
+}
+
 void main() {
-    vec4 posWorld = (ksg_ModelPoseMat * vec4(Position, 1.0));
-    vertexColor = Color;
-    lightMapColor = texelFetch(Sampler2, UV2 / 16, 0);
-    overlayColor = texelFetch(Sampler1, UV1, 0);
+    vec3 skinnedPosition = Position;
+    vec3 skinnedNormal = Normal;
+    vec4 skinnedTangent = Tangent;
+    ksg_applyGpuSkinning(skinnedPosition, skinnedNormal, skinnedTangent);
+
+    vec4 posWorld = (ksg_ModelPoseMat * vec4(skinnedPosition, 1.0));
+    vertexColor = vec4(Color.rgb * ksg_BrightnessScale, Color.a);
+    lightMapColor = texelFetch(Sampler2, ksg_PackedLight / 16, 0);
+    overlayColor = texelFetch(Sampler1, ksg_PackedOverlay, 0);
 
     texCoord0 = UV0;
     vec4 viewPos4 = ModelViewMat * posWorld;
     viewPos = viewPos4.xyz;
     vertexDistance = fog_distance(viewPos, FogShape);
     mat3 normalMatrix = mat3(ModelViewMat) * ksg_ModelNormalMat;
-    viewNormal = normalize(normalMatrix * Normal);
+    viewNormal = normalize(normalMatrix * skinnedNormal);
 
-    vec3 T = normalize(normalMatrix * Tangent.xyz);
-    vec3 B = cross(viewNormal, T) * Tangent.w;
+    vec3 T = normalize(normalMatrix * skinnedTangent.xyz);
+    vec3 B = cross(viewNormal, T) * skinnedTangent.w;
     TBN = mat3(T, B, viewNormal);
 
     mat3 viewRot = mat3(ModelViewMat);


### PR DESCRIPTION
  - move brightness, packedLight, and packedOverlay updates out of static VBO rebuilds
  - add shader uniforms for model lighting and overlay state
  - add bone indices/weights to the UML vertex format
  - upload bone transforms through a texture buffer for GPU skinning
  - skip CPU vertex skinning on the non-Iris custom shader path when enabled
  - keep Iris shader-pack rendering on the CPU skinning fallback path
  - add profiling markers for uniform light updates and GPU bone uploads